### PR TITLE
Avoid panics on arrays

### DIFF
--- a/messagediff.go
+++ b/messagediff.go
@@ -91,7 +91,7 @@ func (d *Diff) diff(aVal, bVal reflect.Value, path Path) bool {
 
 	equal := true
 	switch kind {
-	case reflect.Array, reflect.Map, reflect.Ptr, reflect.Func, reflect.Chan, reflect.Slice:
+	case reflect.Map, reflect.Ptr, reflect.Func, reflect.Chan, reflect.Slice:
 		if aVal.IsNil() && bVal.IsNil() {
 			return true
 		}

--- a/messagediff_test.go
+++ b/messagediff_test.go
@@ -8,6 +8,7 @@ import (
 type testStruct struct {
 	A, b int
 	C    []int
+	D    [3]int
 }
 
 type RecursiveStruct struct {
@@ -90,8 +91,8 @@ func TestPrettyDiff(t *testing.T) {
 			false,
 		},
 		{
-			testStruct{1, 2, []int{1}},
-			testStruct{1, 3, []int{1, 2}},
+			testStruct{1, 2, []int{1}, [3]int{4, 5, 6}},
+			testStruct{1, 3, []int{1, 2}, [3]int{4, 5, 6}},
 			"added: .C[1] = 2\nmodified: .b = 3\n",
 			false,
 		},


### PR DESCRIPTION
Having an array type on a field struct panic.

This PR added the test case and the fix.