### PR TITLE
Make sure path is not incorrectly modified via ref

### DIFF
--- a/example/atom_test.go
+++ b/example/atom_test.go
@@ -13,7 +13,7 @@ func ExampleAtom() {
 	want := data1()
 	diff, equal := messagediff.PrettyDiff(want, got)
 	fmt.Printf("%v %s", equal, diff)
-	// Output: false modified: [0].FirstChild.NextSibling.Attr = " baz"
+	// Output: false modified: [0].FirstChild.NextSibling.Data = " baz"
 }
 
 func data1() []*html.Node {

--- a/messagediff.go
+++ b/messagediff.go
@@ -41,20 +41,25 @@ func newDiff() *Diff {
 }
 
 func (d *Diff) diff(aVal, bVal reflect.Value, path Path) bool {
+	// The array underlying `path` could be modified in subsequent
+	// calls. Make sure we have a local copy.
+	localPath := make(Path, len(path))
+	copy(localPath, path)
+
 	// Validity checks. Should only trigger if nil is one of the original arguments.
 	if !aVal.IsValid() && !bVal.IsValid() {
 		return true
 	}
 	if !bVal.IsValid() {
-		d.Modified[&path] = nil
+		d.Modified[&localPath] = nil
 		return false
 	} else if !aVal.IsValid() {
-		d.Modified[&path] = bVal.Interface()
+		d.Modified[&localPath] = bVal.Interface()
 		return false
 	}
 
 	if aVal.Type() != bVal.Type() {
-		d.Modified[&path] = bVal.Interface()
+		d.Modified[&localPath] = bVal.Interface()
 		return false
 	}
 	kind := aVal.Kind()
@@ -96,7 +101,7 @@ func (d *Diff) diff(aVal, bVal reflect.Value, path Path) bool {
 			return true
 		}
 		if aVal.IsNil() || bVal.IsNil() {
-			d.Modified[&path] = bVal.Interface()
+			d.Modified[&localPath] = bVal.Interface()
 			return false
 		}
 	}
@@ -106,20 +111,20 @@ func (d *Diff) diff(aVal, bVal reflect.Value, path Path) bool {
 		aLen := aVal.Len()
 		bLen := bVal.Len()
 		for i := 0; i < min(aLen, bLen); i++ {
-			localPath := append(path, SliceIndex(i))
+			localPath := append(localPath, SliceIndex(i))
 			if eq := d.diff(aVal.Index(i), bVal.Index(i), localPath); !eq {
 				equal = false
 			}
 		}
 		if aLen > bLen {
 			for i := bLen; i < aLen; i++ {
-				localPath := append(path, SliceIndex(i))
+				localPath := append(localPath, SliceIndex(i))
 				d.Removed[&localPath] = aVal.Index(i).Interface()
 				equal = false
 			}
 		} else if aLen < bLen {
 			for i := aLen; i < bLen; i++ {
-				localPath := append(path, SliceIndex(i))
+				localPath := append(localPath, SliceIndex(i))
 				d.Added[&localPath] = bVal.Index(i).Interface()
 				equal = false
 			}
@@ -128,7 +133,7 @@ func (d *Diff) diff(aVal, bVal reflect.Value, path Path) bool {
 		for _, key := range aVal.MapKeys() {
 			aI := aVal.MapIndex(key)
 			bI := bVal.MapIndex(key)
-			localPath := append(path, MapKey{key.Interface()})
+			localPath := append(localPath, MapKey{key.Interface()})
 			if !bI.IsValid() {
 				d.Removed[&localPath] = aI.Interface()
 				equal = false
@@ -140,7 +145,7 @@ func (d *Diff) diff(aVal, bVal reflect.Value, path Path) bool {
 			aI := aVal.MapIndex(key)
 			if !aI.IsValid() {
 				bI := bVal.MapIndex(key)
-				localPath := append(path, MapKey{key.Interface()})
+				localPath := append(localPath, MapKey{key.Interface()})
 				d.Added[&localPath] = bI.Interface()
 				equal = false
 			}
@@ -150,7 +155,7 @@ func (d *Diff) diff(aVal, bVal reflect.Value, path Path) bool {
 		for i := 0; i < typ.NumField(); i++ {
 			index := []int{i}
 			field := typ.FieldByIndex(index)
-			localPath := append(path, StructField(field.Name))
+			localPath := append(localPath, StructField(field.Name))
 			aI := unsafeReflectValue(aVal.FieldByIndex(index))
 			bI := unsafeReflectValue(bVal.FieldByIndex(index))
 			if eq := d.diff(aI, bI, localPath); !eq {
@@ -158,12 +163,12 @@ func (d *Diff) diff(aVal, bVal reflect.Value, path Path) bool {
 			}
 		}
 	case reflect.Ptr:
-		equal = d.diff(aVal.Elem(), bVal.Elem(), path)
+		equal = d.diff(aVal.Elem(), bVal.Elem(), localPath)
 	default:
 		if reflect.DeepEqual(aVal.Interface(), bVal.Interface()) {
 			equal = true
 		} else {
-			d.Modified[&path] = bVal.Interface()
+			d.Modified[&localPath] = bVal.Interface()
 			equal = false
 		}
 	}


### PR DESCRIPTION
Sometimes, the path name would be incorrectly listed as the last path processed. This makes sure the path is not updated via the `path` pointer.