### PR TITLE
test: fixed TestPrettyDiff on tip

### DIFF
--- a/messagediff_test.go
+++ b/messagediff_test.go
@@ -122,8 +122,8 @@ func TestPrettyDiff(t *testing.T) {
 		},
 		{
 			time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC),
-			time.Time{},
-			"modified: .loc = (*time.Location)(nil)\nmodified: .sec = 0\n",
+			time.Date(1, 1, 1, 0, 0, 0, 0, time.UTC),
+			"modified: .sec = 0\n",
 			false,
 		},
 	}


### PR DESCRIPTION
Internal changes to how the time.Time type works required this fix. Should be a
better anyways since it's no longer relying on unspecified behavior of
time.Time{}.