### PR TITLE
Added ability to ignore fields by tagging them.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## nightly
+* Added support for ignoring fields.
+
 ## v1.1.0
 
 * Added support for recursive data structures.

--- a/README.md
+++ b/README.md
@@ -20,12 +20,11 @@ import "gopkg.in/d4l3k/messagediff.v1"
 type someStruct struct {
   A, b int
   C []int
-  D int `testdiff:"ignore"`
 }
 
 func main() {
-			a := someStruct{1, 2, []int{1}, 9}
-			b := someStruct{1, 3, []int{1, 2}, 10}
+			a := someStruct{1, 2, []int{1}}
+			b := someStruct{1, 3, []int{1, 2}}
       diff, equal := messagediff.PrettyDiff(a, b)
       /*
         diff =
@@ -54,6 +53,28 @@ func TestSomething(t *testing.T) {
   if diff, equal := messagediff.PrettyDiff(want, got); !equal {
     t.Errorf("Something() = %#v\n%s", got, diff)
   }
+}
+```
+To ignore a field in a struct, just annotate it with testdiff:"ignore" like
+this:
+```go
+package main
+
+import "gopkg.in/d4l3k/messagediff.v1"
+
+type someStruct struct {
+  A int
+  B int `testdiff:"ignore"`
+}
+
+func main() {
+			a := someStruct{1, 2}
+			b := someStruct{1, 3}
+      diff, equal := messagediff.PrettyDiff(a, b)
+      /*
+        equal = true
+        diff = ""
+      */
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ If the unsafe package is available messagediff will diff unexported fields in
 addition to exported fields. This is primarily used for testing purposes as it
 allows for providing informative error messages.
 
+Optionally, fields in structs can be tagged as `testdiff:"ignore"` to make
+messagediff skip it when doing the comparison.
+
 
 ## Example Usage
 In a normal file:
@@ -17,11 +20,12 @@ import "gopkg.in/d4l3k/messagediff.v1"
 type someStruct struct {
   A, b int
   C []int
+  D int `testdiff:"ignore"`
 }
 
 func main() {
-			a := someStruct{1, 2, []int{1}}
-			b := someStruct{1, 3, []int{1, 2}}
+			a := someStruct{1, 2, []int{1}, 9}
+			b := someStruct{1, 3, []int{1, 2}, 10}
       diff, equal := messagediff.PrettyDiff(a, b)
       /*
         diff =

--- a/README.md
+++ b/README.md
@@ -18,21 +18,21 @@ package main
 import "gopkg.in/d4l3k/messagediff.v1"
 
 type someStruct struct {
-  A, b int
-  C []int
+    A, b int
+    C []int
 }
 
 func main() {
-			a := someStruct{1, 2, []int{1}}
-			b := someStruct{1, 3, []int{1, 2}}
-      diff, equal := messagediff.PrettyDiff(a, b)
-      /*
+    a := someStruct{1, 2, []int{1}}
+    b := someStruct{1, 3, []int{1, 2}}
+    diff, equal := messagediff.PrettyDiff(a, b)
+    /*
         diff =
-          `added: .C[1] = 2
-          modified: .b = 3`
+        `added: .C[1] = 2
+        modified: .b = 3`
 
         equal = false
-      */
+    */
 }
 
 ```
@@ -43,16 +43,16 @@ import "gopkg.in/d4l3k/messagediff.v1"
 ...
 
 type someStruct struct {
-  A, b int
-  C []int
+    A, b int
+    C []int
 }
 
 func TestSomething(t *testing.T) {
-  want := someStruct{1, 2, []int{1}}
-  got := someStruct{1, 3, []int{1, 2}}
-  if diff, equal := messagediff.PrettyDiff(want, got); !equal {
-    t.Errorf("Something() = %#v\n%s", got, diff)
-  }
+    want := someStruct{1, 2, []int{1}}
+    got := someStruct{1, 3, []int{1, 2}}
+    if diff, equal := messagediff.PrettyDiff(want, got); !equal {
+        t.Errorf("Something() = %#v\n%s", got, diff)
+    }
 }
 ```
 To ignore a field in a struct, just annotate it with testdiff:"ignore" like
@@ -63,18 +63,18 @@ package main
 import "gopkg.in/d4l3k/messagediff.v1"
 
 type someStruct struct {
-  A int
-  B int `testdiff:"ignore"`
+    A int
+    B int `testdiff:"ignore"`
 }
 
 func main() {
-			a := someStruct{1, 2}
-			b := someStruct{1, 3}
-      diff, equal := messagediff.PrettyDiff(a, b)
-      /*
+    a := someStruct{1, 2}
+    b := someStruct{1, 3}
+    diff, equal := messagediff.PrettyDiff(a, b)
+    /*
         equal = true
         diff = ""
-      */
+    */
 }
 ```
 

--- a/messagediff.go
+++ b/messagediff.go
@@ -155,6 +155,9 @@ func (d *Diff) diff(aVal, bVal reflect.Value, path Path) bool {
 		for i := 0; i < typ.NumField(); i++ {
 			index := []int{i}
 			field := typ.FieldByIndex(index)
+			if field.Tag.Get("testdiff") == "ignore" { // skip fields marked to be ignored
+				continue
+			}
 			localPath := append(localPath, StructField(field.Name))
 			aI := unsafeReflectValue(aVal.FieldByIndex(index))
 			bI := unsafeReflectValue(bVal.FieldByIndex(index))

--- a/messagediff_test.go
+++ b/messagediff_test.go
@@ -11,6 +11,7 @@ type testStruct struct {
 	A, b int
 	C    []int
 	D    [3]int
+	E    int `testdiff:"ignore"`
 }
 
 type RecursiveStruct struct {
@@ -93,8 +94,8 @@ func TestPrettyDiff(t *testing.T) {
 			false,
 		},
 		{
-			testStruct{1, 2, []int{1}, [3]int{4, 5, 6}},
-			testStruct{1, 3, []int{1, 2}, [3]int{4, 5, 6}},
+			testStruct{1, 2, []int{1}, [3]int{4, 5, 6}, 9},
+			testStruct{1, 3, []int{1, 2}, [3]int{4, 5, 6}, 10},
 			"added: .C[1] = 2\nmodified: .b = 3\n",
 			false,
 		},

--- a/messagediff_test.go
+++ b/messagediff_test.go
@@ -11,7 +11,6 @@ type testStruct struct {
 	A, b int
 	C    []int
 	D    [3]int
-	E    int `testdiff:"ignore"`
 }
 
 type RecursiveStruct struct {
@@ -94,8 +93,8 @@ func TestPrettyDiff(t *testing.T) {
 			false,
 		},
 		{
-			testStruct{1, 2, []int{1}, [3]int{4, 5, 6}, 9},
-			testStruct{1, 3, []int{1, 2}, [3]int{4, 5, 6}, 10},
+			testStruct{1, 2, []int{1}, [3]int{4, 5, 6}},
+			testStruct{1, 3, []int{1, 2}, [3]int{4, 5, 6}},
 			"added: .C[1] = 2\nmodified: .b = 3\n",
 			false,
 		},
@@ -163,5 +162,32 @@ func TestPathString(t *testing.T) {
 		if out := td.in.String(); out != td.want {
 			t.Errorf("%d. %#v.String() = %#v; not %#v", i, td.in, out, td.want)
 		}
+	}
+}
+
+type ignoreStruct struct {
+	A int `testdiff:"ignore"`
+	a int
+	B [3]int `testdiff:"ignore"`
+	b [3]int
+}
+
+func TestIgnoreTag(t *testing.T) {
+	s1 := ignoreStruct{1, 1, [3]int{1, 2, 3}, [3]int{4, 5, 6}}
+	s2 := ignoreStruct{2, 1, [3]int{1, 8, 3}, [3]int{4, 5, 6}}
+
+	diff, equal := PrettyDiff(s1, s2)
+	if !equal {
+		t.Errorf("Expected structs to be equal. Diff:\n%s", diff)
+	}
+
+	s2 = ignoreStruct{2, 2, [3]int{1, 8, 3}, [3]int{4, 9, 6}}
+	diff, equal = PrettyDiff(s1, s2)
+	if equal {
+		t.Errorf("Expected structs NOT to be equal.")
+	}
+	expect := "modified: .a = 2\nmodified: .b[1] = 9\n"
+	if diff != expect {
+		t.Errorf("Expected diff to be:\n%v\nbut got:\n%v", expect, diff)
 	}
 }


### PR DESCRIPTION
Added code and tests to support tagging fields with testdiff:"ignore".
Adding this tag to any field will make messagediff skip this field.
This is useful for transient fields that do not store actual value of
the struct. I have used generic 'testdiff' tag to potentially make it
usable by other libraries who might want to do the same purpose.