### PR TITLE
pass ignore as args

### DIFF
--- a/messagediff.go
+++ b/messagediff.go
@@ -11,8 +11,8 @@ import (
 
 // PrettyDiff does a deep comparison and returns the nicely formated results.
 // See DeepDiff for more details.
-func PrettyDiff(a, b interface{}, ignores ...string) (string, bool) {
-	d, equal := DeepDiff(a, b, ignores...)
+func PrettyDiff(a, b interface{}, options ...Option) (string, bool) {
+	d, equal := DeepDiff(a, b, options...)
 	var dstr []string
 	for path, added := range d.Added {
 		dstr = append(dstr, fmt.Sprintf("added: %s = %#v\n", path.String(), added))
@@ -29,9 +29,9 @@ func PrettyDiff(a, b interface{}, ignores ...string) (string, bool) {
 
 // DeepDiff does a deep comparison and returns the results.
 // If the field is time.Time, use Equal to compare
-func DeepDiff(a, b interface{}, ignores ...string) (*Diff, bool) {
+func DeepDiff(a, b interface{}, options ...Option) (*Diff, bool) {
 	d := newDiff()
-	return d, d.diff(reflect.ValueOf(a), reflect.ValueOf(b), nil, ignores...)
+	return d, d.diff(reflect.ValueOf(a), reflect.ValueOf(b), nil, options...)
 }
 
 func newDiff() *Diff {
@@ -43,7 +43,7 @@ func newDiff() *Diff {
 	}
 }
 
-func (d *Diff) diff(aVal, bVal reflect.Value, path Path, ignores ...string) bool {
+func (d *Diff) diff(aVal, bVal reflect.Value, path Path, options ...Option) bool {
 	// The array underlying `path` could be modified in subsequent
 	// calls. Make sure we have a local copy.
 	localPath := make(Path, len(path))
@@ -115,7 +115,7 @@ func (d *Diff) diff(aVal, bVal reflect.Value, path Path, ignores ...string) bool
 		bLen := bVal.Len()
 		for i := 0; i < min(aLen, bLen); i++ {
 			localPath := append(localPath, SliceIndex(i))
-			if eq := d.diff(aVal.Index(i), bVal.Index(i), localPath, ignores...); !eq {
+			if eq := d.diff(aVal.Index(i), bVal.Index(i), localPath, options...); !eq {
 				equal = false
 			}
 		}
@@ -140,7 +140,7 @@ func (d *Diff) diff(aVal, bVal reflect.Value, path Path, ignores ...string) bool
 			if !bI.IsValid() {
 				d.Removed[&localPath] = aI.Interface()
 				equal = false
-			} else if eq := d.diff(aI, bI, localPath, ignores...); !eq {
+			} else if eq := d.diff(aI, bI, localPath, options...); !eq {
 				equal = false
 			}
 		}
@@ -164,32 +164,28 @@ func (d *Diff) diff(aVal, bVal reflect.Value, path Path, ignores ...string) bool
 				equal = false
 			}
 		} else {
+		FIELDS_LOOP:
 			for i := 0; i < typ.NumField(); i++ {
 				index := []int{i}
 				field := typ.FieldByIndex(index)
 				if field.Tag.Get("testdiff") == "ignore" { // skip fields marked to be ignored
 					continue
 				}
-				skip := false
-				for _, ig := range ignores {
-					if field.Name == ig {
-						skip = true
-						break
+				for _, o := range options {
+					if skip := o.apply(&opts{field: field}); skip {
+						break FIELDS_LOOP
 					}
-				}
-				if skip {
-					continue
 				}
 				localPath := append(localPath, StructField(field.Name))
 				aI := unsafeReflectValue(aVal.FieldByIndex(index))
 				bI := unsafeReflectValue(bVal.FieldByIndex(index))
-				if eq := d.diff(aI, bI, localPath, ignores...); !eq {
+				if eq := d.diff(aI, bI, localPath, options...); !eq {
 					equal = false
 				}
 			}
 		}
 	case reflect.Ptr:
-		equal = d.diff(aVal.Elem(), bVal.Elem(), localPath, ignores...)
+		equal = d.diff(aVal.Elem(), bVal.Elem(), localPath, options...)
 	default:
 		if reflect.DeepEqual(aVal.Interface(), bVal.Interface()) {
 			equal = true
@@ -262,4 +258,32 @@ type SliceIndex int
 
 func (n SliceIndex) String() string {
 	return fmt.Sprintf("[%d]", n)
+}
+
+type opts struct {
+	field reflect.StructField
+}
+
+// Option is an option to specify in diff
+type Option interface {
+	apply(*opts) bool
+}
+
+// IgnoreStructField return an option of IgnoreFieldOption
+func IgnoreStructField(field string) Option {
+	return IgnoreFieldOption{
+		Field: field,
+	}
+}
+
+// IgnoreFieldOption is an option for specifying a field that does not diff
+type IgnoreFieldOption struct {
+	Field string
+}
+
+func (i IgnoreFieldOption) apply(opts *opts) (skip bool) {
+	if opts == nil {
+		return false
+	}
+	return i.Field == opts.field.Name
 }

--- a/messagediff.go
+++ b/messagediff.go
@@ -11,8 +11,8 @@ import (
 
 // PrettyDiff does a deep comparison and returns the nicely formated results.
 // See DeepDiff for more details.
-func PrettyDiff(a, b interface{}) (string, bool) {
-	d, equal := DeepDiff(a, b)
+func PrettyDiff(a, b interface{}, ignores ...string) (string, bool) {
+	d, equal := DeepDiff(a, b, ignores...)
 	var dstr []string
 	for path, added := range d.Added {
 		dstr = append(dstr, fmt.Sprintf("added: %s = %#v\n", path.String(), added))
@@ -29,9 +29,9 @@ func PrettyDiff(a, b interface{}) (string, bool) {
 
 // DeepDiff does a deep comparison and returns the results.
 // If the field is time.Time, use Equal to compare
-func DeepDiff(a, b interface{}) (*Diff, bool) {
+func DeepDiff(a, b interface{}, ignores ...string) (*Diff, bool) {
 	d := newDiff()
-	return d, d.diff(reflect.ValueOf(a), reflect.ValueOf(b), nil)
+	return d, d.diff(reflect.ValueOf(a), reflect.ValueOf(b), nil, ignores...)
 }
 
 func newDiff() *Diff {
@@ -43,7 +43,7 @@ func newDiff() *Diff {
 	}
 }
 
-func (d *Diff) diff(aVal, bVal reflect.Value, path Path) bool {
+func (d *Diff) diff(aVal, bVal reflect.Value, path Path, ignores ...string) bool {
 	// The array underlying `path` could be modified in subsequent
 	// calls. Make sure we have a local copy.
 	localPath := make(Path, len(path))
@@ -115,7 +115,7 @@ func (d *Diff) diff(aVal, bVal reflect.Value, path Path) bool {
 		bLen := bVal.Len()
 		for i := 0; i < min(aLen, bLen); i++ {
 			localPath := append(localPath, SliceIndex(i))
-			if eq := d.diff(aVal.Index(i), bVal.Index(i), localPath); !eq {
+			if eq := d.diff(aVal.Index(i), bVal.Index(i), localPath, ignores...); !eq {
 				equal = false
 			}
 		}
@@ -140,7 +140,7 @@ func (d *Diff) diff(aVal, bVal reflect.Value, path Path) bool {
 			if !bI.IsValid() {
 				d.Removed[&localPath] = aI.Interface()
 				equal = false
-			} else if eq := d.diff(aI, bI, localPath); !eq {
+			} else if eq := d.diff(aI, bI, localPath, ignores...); !eq {
 				equal = false
 			}
 		}
@@ -170,16 +170,26 @@ func (d *Diff) diff(aVal, bVal reflect.Value, path Path) bool {
 				if field.Tag.Get("testdiff") == "ignore" { // skip fields marked to be ignored
 					continue
 				}
+				skip := false
+				for _, ig := range ignores {
+					if field.Name == ig {
+						skip = true
+						break
+					}
+				}
+				if skip {
+					continue
+				}
 				localPath := append(localPath, StructField(field.Name))
 				aI := unsafeReflectValue(aVal.FieldByIndex(index))
 				bI := unsafeReflectValue(bVal.FieldByIndex(index))
-				if eq := d.diff(aI, bI, localPath); !eq {
+				if eq := d.diff(aI, bI, localPath, ignores...); !eq {
 					equal = false
 				}
 			}
 		}
 	case reflect.Ptr:
-		equal = d.diff(aVal.Elem(), bVal.Elem(), localPath)
+		equal = d.diff(aVal.Elem(), bVal.Elem(), localPath, ignores...)
 	default:
 		if reflect.DeepEqual(aVal.Interface(), bVal.Interface()) {
 			equal = true

--- a/messagediff.go
+++ b/messagediff.go
@@ -168,7 +168,6 @@ func (d *Diff) diff(aVal, bVal reflect.Value, path Path, opts *opts) bool {
 				equal = false
 			}
 		} else {
-		FIELDS_LOOP:
 			for i := 0; i < typ.NumField(); i++ {
 				index := []int{i}
 				field := typ.FieldByIndex(index)
@@ -176,9 +175,8 @@ func (d *Diff) diff(aVal, bVal reflect.Value, path Path, opts *opts) bool {
 					continue
 				}
 				if _, skip := opts.ignoreField[field.Name]; skip {
-					continue FIELDS_LOOP
+					continue
 				}
-
 				localPath := append(localPath, StructField(field.Name))
 				aI := unsafeReflectValue(aVal.FieldByIndex(index))
 				bI := unsafeReflectValue(bVal.FieldByIndex(index))

--- a/messagediff_test.go
+++ b/messagediff_test.go
@@ -203,3 +203,34 @@ func TestIgnoreTag(t *testing.T) {
 		t.Errorf("Expected diff to be:\n%v\nbut got:\n%v", expect, diff)
 	}
 }
+
+func TestIgnoreByArgs(t *testing.T) {
+	a := struct {
+		X string
+		Y string
+	}{
+		X: "x",
+		Y: "y",
+	}
+	b := struct {
+		X string
+		Y string
+	}{
+		X: "xx",
+		Y: "y",
+	}
+
+	diff, equal := PrettyDiff(a, b, "X")
+	if !equal {
+		t.Errorf("Expected structs to be equal. Diff:\n%s", diff)
+	}
+
+	diff, equal = PrettyDiff(a, b, "Y")
+	if equal {
+		t.Errorf("Expected structs NOT to be equal.")
+	}
+	expect := "modified: .X = \"xx\"\n"
+	if diff != expect {
+		t.Errorf("Expected diff to be:\n%v\nbut got:\n%v", expect, diff)
+	}
+}

--- a/messagediff_test.go
+++ b/messagediff_test.go
@@ -204,7 +204,7 @@ func TestIgnoreTag(t *testing.T) {
 	}
 }
 
-func TestIgnoreByArgs(t *testing.T) {
+func TestIgnoreStructFieldOption(t *testing.T) {
 	a := struct {
 		X string
 		Y string
@@ -220,12 +220,12 @@ func TestIgnoreByArgs(t *testing.T) {
 		Y: "y",
 	}
 
-	diff, equal := PrettyDiff(a, b, "X")
+	diff, equal := PrettyDiff(a, b, IgnoreStructField("X"))
 	if !equal {
 		t.Errorf("Expected structs to be equal. Diff:\n%s", diff)
 	}
 
-	diff, equal = PrettyDiff(a, b, "Y")
+	diff, equal = PrettyDiff(a, b, IgnoreStructField("Y"))
 	if equal {
 		t.Errorf("Expected structs NOT to be equal.")
 	}


### PR DESCRIPTION
Hi, Thank you for a wonderful tool

There is a function I want to add one, and I added.

Currently, I can use tags to specify items I do not want to compare, but in some cases I do not want to use tags. (For example, a struct created by automatic generation). Therefore, it changed so that I can specify the name of the struct I want to ignore recursively with the function argument.

If something is missing or you have any changes, I will fix it.
Feedback please.