### PR TITLE
Travis-ci: Added power support for ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,17 @@
 language: go
 
+arch:
+  - AMD64
+  - ppc64le
+
+go_import_path: github.com/d4l3k/messagediff
+
 os:
   - linux
 
 go:
-  - 1.9.x
-  - 1.10.x
+  - 1.14.x
+  - 1.15.x
   - tip
 
 allow_failures:


### PR DESCRIPTION
Signed-off-by: Devendranath Thadi <devendranath.thadi3@gmail.com>

Added power support for the travis.yml file with ppc64le & updated latest go versions. This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing.